### PR TITLE
change the type for bind password field

### DIFF
--- a/src/webviews/createAddEditConnectionWebview.ts
+++ b/src/webviews/createAddEditConnectionWebview.ts
@@ -73,7 +73,7 @@ export function createAddEditConnectionWebview(context: ExtensionContext, existi
           <vscode-text-field type="text" id="binddn" placeholder="e.g. cn=admin,dc=example,dc=org" value="${existingConnection?.getBindDn(false) ?? ''}">Bind DN</vscode-text-field>
         </section>
         <section>
-          <vscode-text-field type="text" id="bindpwd" value="${existingConnection?.getBindPwd(false) ?? ''}">Bind Password</vscode-text-field>
+          <vscode-text-field type="password" id="bindpwd" value="${existingConnection?.getBindPwd(false) ?? ''}">Bind Password</vscode-text-field>
         </section>
         <section>
           <vscode-text-field type="text" id="basedn" placeholder="e.g. dc=example,dc=org" value="${existingConnection?.getBaseDn(false) ?? ''}">Base DN *</vscode-text-field>


### PR DESCRIPTION
The password field is sensitive information, sometimes we need to show colleagues the configuration of this extension, it is better to mask it as password.