### PR TITLE
Decode binary ObjectSid to its string representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ Name of binary attributes (case insentitive). They will be represented as Base64
 
 * **ldap-explorer.binary-decode** (`true`)
 
-If `true` then the `objectGUID` binary attribute will be decoded and represented as a UUID (regardless of whether `objectGUID` is listed in `ldap-explorer.binary-attributes`).
+If `true` then the `objectGUID` and `objectSid` binary attributes will be decoded and represented as text values regardless of whether they are listed in `ldap-explorer.binary-attributes`.
+
+  - `objectGUID` will be represented as UUID text.
+  - `objectSid` will be represented as Microsoft Active Directory security identifier (SID) text.
 
 * **ldap-explorer.cacerts** (`[]`)
 

--- a/package.json
+++ b/package.json
@@ -296,7 +296,7 @@
         "ldap-explorer.binary-decode": {
           "type": "boolean",
           "title": "Decode binary attributes",
-          "description": "Whether the 'objectGUID' binary attribute should be decoded and represented as a UUID.",
+          "description": "Whether the 'objectGUID', 'objectSid' binary attributes should be decoded and represented as text values.",
           "default": true
         },
         "ldap-explorer.cacerts": {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -84,6 +84,9 @@ suite('Extension test suite', () => {
 
     assert.strictEqual("{32b1434c-cc5f-4ec1-8afa-e14c300a9070}", 
       utils.binaryGUIDToTextUUID(Buffer.from("TEOxMl/MwU6K+uFMMAqQcA==", "base64")));
+
+    assert.strictEqual("{541be56a-668c-4e78-a317-7fb201d5abc0}", 
+      utils.binaryGUIDToTextUUID(Buffer.from("auUbVIxmeE6jF3+yAdWrwA==", "base64")));
   });
 
   test('Test binarySIDToText', () => {
@@ -96,8 +99,8 @@ suite('Extension test suite', () => {
     assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1130", 
       utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+agQAAA==", "base64")));
 
-    assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1129", 
-      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+aQQAAA==", "base64")));
+    assert.strictEqual("S-1-5-21-3316208387-3203859757-1631524618-1117", 
+      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAAA1OpxS0F974KFz9hXQQAAA==", "base64")));
   });
 
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { LdapConnection } from '../../LdapConnection';
+import * as utils from '../../webviews/utils';
 
 suite('Extension test suite', () => {
 
@@ -72,6 +73,20 @@ suite('Extension test suite', () => {
     assert.strictEqual("0", connection.getLimit(true));
     assert.strictEqual("true", connection.getPaged(true));
     assert.strictEqual("5000", connection.getTimeout(true));
+  });
+
+  test('Test binarySIDToText', () => {
+    assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1103", 
+      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+TwQAAA==", "base64")));
+
+    assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1140", 
+      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+dAQAAA==", "base64")));
+
+    assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1130", 
+      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+agQAAA==", "base64")));
+
+    assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1129", 
+      utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+aQQAAA==", "base64")));
   });
 
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -75,6 +75,17 @@ suite('Extension test suite', () => {
     assert.strictEqual("5000", connection.getTimeout(true));
   });
 
+  test('Test binaryGUIDToTextUUID', () => {
+    assert.strictEqual("{7f613d2a-b1ed-469b-9252-a804d4310c88}", 
+      utils.binaryGUIDToTextUUID(Buffer.from("Kj1hf+2xm0aSUqgE1DEMiA==", "base64")));
+
+    assert.strictEqual("{ebaf4bc1-9068-4842-a6e5-8955bff33a6f}", 
+      utils.binaryGUIDToTextUUID(Buffer.from("wUuv62iQQkim5YlVv/M6bw==", "base64")));
+
+    assert.strictEqual("{32b1434c-cc5f-4ec1-8afa-e14c300a9070}", 
+      utils.binaryGUIDToTextUUID(Buffer.from("TEOxMl/MwU6K+uFMMAqQcA==", "base64")));
+  });
+
   test('Test binarySIDToText', () => {
     assert.strictEqual("S-1-5-21-4169144328-3425172002-2123581430-1103", 
       utils.binarySIDToText(Buffer.from("AQUAAAAAAAUVAAAACBiA+CL6J8z2R5N+TwQAAA==", "base64")));

--- a/src/webviews/utils.ts
+++ b/src/webviews/utils.ts
@@ -18,7 +18,7 @@ function binaryToBase64(binary: Buffer) {
  * @see https://en.wikipedia.org/wiki/Universally_unique_identifier
  * @see https://github.com/fengtan/ldap-explorer/pull/60
  */
-function binaryGUIDToTextUUID(binary: Buffer) {
+export function binaryGUIDToTextUUID(binary: Buffer) {
   const dashPos = [4, 6, 8, 10];
   let uuid = "";
 

--- a/src/webviews/utils.ts
+++ b/src/webviews/utils.ts
@@ -49,7 +49,7 @@ function binaryGUIDToTextUUID(binary: Buffer) {
  * @see https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers 
  * @see https://learn.microsoft.com/en-us/windows/win32/adschema/a-objectsid
  */
-function binarySIDToText(binary: Buffer) {
+export function binarySIDToText(binary: Buffer) {
   if (binary.length < 8) {
     return "Invalid SID: less than 8 bytes";
   }


### PR DESCRIPTION
Adds support for security identifier (SID) `objectSid` attribute decoding.

I've also added a bunch of unit tests for both `objectGUID` and `objectSid`, based on values as shown in Apace Directory Studio.