### PR TITLE
Add connectTimeout LdapConnection field with default value of 5000 ms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ List of LDAP connections. Example:
       "basedn": "dc=example,dc=org",
       "limit": "0",
       "paged": "true",
+      "connectTimeout": "5000",
       "timeout": "5000",
       "bookmarks": [
         "cn=readers,ou=users,dc=example,dc=org"

--- a/assets/js/createAddEditConnectionWebview.js
+++ b/assets/js/createAddEditConnectionWebview.js
@@ -18,6 +18,7 @@ function submitForm(command) {
     basedn: document.getElementById("basedn").value,
     limit: document.getElementById("limit").value,
     paged: document.getElementById("paged").checked ? "true" : "false",
+    connectTimeout: document.getElementById("connectTimeout").value,
     timeout: document.getElementById("timeout").value
   });
 }

--- a/package.json
+++ b/package.json
@@ -377,6 +377,11 @@
                 "description": "Size Limit",
                 "default": "0"
               },
+              "connectTimeout": {
+                "type": "string",
+                "description": "Connect timeout (milliseconds)",
+                "default": "5000"
+              },
               "timeout": {
                 "type": "string",
                 "description": "Timeout (milliseconds)",

--- a/src/LdapConnection.ts
+++ b/src/LdapConnection.ts
@@ -25,6 +25,7 @@ export class LdapConnection {
   private basedn: string;
   private limit: string;
   private paged: string;
+  private connectTimeout: string;
   private timeout: string;
   private bookmarks: string[];
 
@@ -41,6 +42,7 @@ export class LdapConnection {
     basedn: string,
     limit: string,
     paged: string,
+    connectTimeout: string,
     timeout: string,
     bookmarks: string[]
   ) {
@@ -56,6 +58,7 @@ export class LdapConnection {
     this.basedn = basedn;
     this.limit = limit;
     this.paged = paged;
+    this.connectTimeout = connectTimeout;
     this.timeout = timeout;
     this.bookmarks = bookmarks;
   }
@@ -99,6 +102,9 @@ export class LdapConnection {
   }
   public getTimeout(evaluate: boolean) {
     return this.get(this.timeout, evaluate);
+  }
+  public getConnectTimeout(evaluate: boolean) {
+    return this.get(this.connectTimeout, evaluate);
   }
   public getBookmarks() {
     return this.bookmarks;
@@ -224,6 +230,7 @@ export class LdapConnection {
       // Get ldapjs client.
       const client: Client = createClient({
         url: [this.getUrl()],
+        connectTimeout: Number(this.getConnectTimeout(true)),
         timeout: Number(this.getTimeout(true)),
         tlsOptions: (this.getProtocol(true) === "ldaps" ? this.getTLSOptions() : {}),
       });

--- a/src/LdapConnectionManager.ts
+++ b/src/LdapConnectionManager.ts
@@ -26,6 +26,7 @@ export class LdapConnectionManager {
       connection["basedn"] || "",
       connection["limit"] || "0",
       connection["paged"] || "true",
+      connection["connectTimeout"] || "5000",
       connection["timeout"] || "5000",
       connection["bookmarks"] || []
     ));

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -19,6 +19,7 @@ suite('Extension test suite', () => {
       "0",
       "true",
       "5000",
+      "5000",
       []
     );
     // Assert connection string.
@@ -40,6 +41,7 @@ suite('Extension test suite', () => {
       "${basedn}",
       "${sizelimit}",
       "${paged}",
+      "${connectTimeout}",
       "${timeout}",
       []
     );
@@ -56,6 +58,7 @@ suite('Extension test suite', () => {
       basedn: "dc=example,dc=org",
       sizelimit: "0",
       paged: "true",
+      connectTimeout: "2000",
       timeout: "5000"
     };
     // Assert values.
@@ -71,6 +74,7 @@ suite('Extension test suite', () => {
     assert.strictEqual("dc=example,dc=org", connection.getBaseDn(true));
     assert.strictEqual("0", connection.getLimit(true));
     assert.strictEqual("true", connection.getPaged(true));
+    assert.strictEqual("2000", connection.getConnectTimeout(true));
     assert.strictEqual("5000", connection.getTimeout(true));
   });
 

--- a/src/webviews/createAddEditConnectionWebview.ts
+++ b/src/webviews/createAddEditConnectionWebview.ts
@@ -85,7 +85,10 @@ export function createAddEditConnectionWebview(context: ExtensionContext, existi
           <vscode-checkbox id="paged" checked="${existingConnection?.getPaged(false) ?? 'true'}">Automatic result paging<small><div>Many LDAP servers enforce limits upon the returned result set (commonly 1,000).</div><div>Enable this option to make sure all results are returned.</div>Disable this option if your server does not support paged results.</div></small></vscode-checkbox>
         </section>
         <section>
-          <vscode-text-field type="text" id="timeout" value="${existingConnection?.getTimeout(false) ?? '5000'}">Timeout in milliseconds (leave empty for infinity)</vscode-text-field>
+          <vscode-text-field type="text" id="connectTimeout" value="${existingConnection?.getConnectTimeout(false) ?? '5000'}" size="48">Connect timeout in milliseconds (leave empty for infinity)</vscode-text-field>
+        </section>
+        <section>
+          <vscode-text-field type="text" id="timeout" value="${existingConnection?.getTimeout(false) ?? '5000'}" size="48">Timeout in milliseconds (leave empty for infinity)</vscode-text-field>
         </section>
 
         <section>
@@ -118,6 +121,7 @@ export function createAddEditConnectionWebview(context: ExtensionContext, existi
         message.basedn,
         message.limit,
         message.paged,
+        message.connectTimeout,
         message.timeout,
         // Bookmarks are not editable via the connection add/edit form.
         // Maintain pre-existing bookarks when editing a connection, and default


### PR DESCRIPTION
This PR adds a configurable connection timeout value to use when creating new TCP connections. In general the effect of this is most obvious when attempting to connect to the LDAP server for the first time. If it is not reachable, one would normally want the connection attempt to end ASAP.

In my case I connect to LDAP servers over VPN and sometimes the VPN is not on, so the extension tries to connect forever (infinity) and this forces me to close and reopen VScode.

I think it's set to 0 (infinity) by default in node-ldapjs: https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/lib/client/client.js#L124

